### PR TITLE
Specify the extra C flags when building JerryScript

### DIFF
--- a/deps/jerry-v8/deps/jerryscript.gyp
+++ b/deps/jerry-v8/deps/jerryscript.gyp
@@ -58,6 +58,12 @@
       'sources': [
         '<@(generated_sources)',
       ],
+      'cflags': [
+        '-std=c99',
+        '-pedantic',
+        '-mfpmath=sse',
+        '-msse2',
+      ],
       'conditions': [
         ['want_separate_host_toolset==1', {
           'toolsets': ['host', 'target'],


### PR DESCRIPTION
Force the standard to be C99 and configure to use SSE2.