### PR TITLE
[deps/jerry-v8] Add support for TwoByte strings

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -100,6 +100,25 @@ var TIMEOUT_MAX = 2147483647; // 2^31-1
 
 /* eslint-disable non-ascii-character */
 //
+// ╔════ > Object Map
+// ║
+// ╠══
+// ║ refedLists: { '40': { }, '320': { etc } } (keys of millisecond duration)
+// ╚══          ┌─────────┘
+//              │
+// ╔══          │
+// ║ TimersList { _idleNext: { }, _idlePrev: (self), _timer: (TimerWrap) }
+// ║         ┌────────────────┘
+// ║    ╔══  │                              ^
+// ║    ║    { _idleNext: { },  _idlePrev: { }, _onTimeout: (callback) }
+// ║    ║      ┌───────────┘
+// ║    ║      │                                  ^
+// ║    ║      { _idleNext: { etc },  _idlePrev: { }, _onTimeout: (callback) }
+// ╠══  ╠══
+// ║    ║
+// ║    ╚════ >  Actual JavaScript timeouts
+// ║
+// ╚════ > Linked List
 //
 
 /* eslint-enable non-ascii-character */


### PR DESCRIPTION
As the UTF-16 encoded strings are not supported directly the strings are converted to UTF-8 then the string JS value is created.

In addition revert a previous modification where the non-ascii characters were used causing the js2c.py script to generate TwoByte strings.