### PR TITLE
Comment out Error.captureStackTrace.

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -158,7 +158,8 @@ function (_Error) {
     _this2.actual = actual;
     _this2.expected = expected;
     _this2.operator = operator;
-    Error.captureStackTrace(_assertThisInitialized(_this2), stackStartFn);
+    // TODO: uncomment if captureStackTrace is implemented.
+    //Error.captureStackTrace(_assertThisInitialized(_this2), stackStartFn);
     return _possibleConstructorReturn(_this2);
   }
 


### PR DESCRIPTION
This function is not implemented yet. Commented out this function temporarily to eliminate unnecessary error message.
