### PR TITLE
Guard extra JerryScript specific cleanup call

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -4148,7 +4148,10 @@ inline int Start(Isolate* isolate, IsolateData* isolate_data,
   __lsan_do_leak_check();
 #endif
 
+#ifdef V8JERRY
+  // TODO: remove if weak reference handling is supported in JerryScript.
   isolate->RequestGarbageCollectionForTesting(Isolate::kFullGarbageCollection);
+#endif
 
   return exit_code;
 }


### PR DESCRIPTION
RequestGarbageCollectionForTesting is an extra function call to eliminate weak referenced objects in case of JerryScript. Added a guard around that because v8 doesn't require that.