### PR TITLE
Correct String::Value::Value to create UTF-16 string

### DIFF
--- a/deps/jerry-v8/src/v8jerry_isolate.cpp
+++ b/deps/jerry-v8/src/v8jerry_isolate.cpp
@@ -389,3 +389,19 @@ void JerryIsolate::AddExternalStringResource(v8::String::ExternalStringResource*
 
     m_ext_str_res.push_back(resource);
 }
+
+void JerryIsolate::AddUTF16String(std::u16string* str) {
+    uint16_t* buffer = (uint16_t*) str->c_str();
+    assert(m_utf16strs.find(buffer) == m_utf16strs.end());
+
+    m_utf16strs[buffer] = str;
+}
+
+void JerryIsolate::RemoveUTF16String(uint16_t* buffer) {
+    std::unordered_map<uint16_t*, std::u16string*>::iterator iter = m_utf16strs.find(buffer);
+
+    assert(iter != m_utf16strs.end());
+
+    delete iter->second;
+    m_utf16strs.erase(iter);
+}

--- a/deps/jerry-v8/src/v8jerry_isolate.hpp
+++ b/deps/jerry-v8/src/v8jerry_isolate.hpp
@@ -3,6 +3,7 @@
 
 #include <deque>
 #include <vector>
+#include <unordered_map>
 
 #include <v8.h>
 
@@ -87,6 +88,9 @@ public:
 
     void AddExternalStringResource(v8::String::ExternalStringResource* resource);
 
+    void AddUTF16String(std::u16string*);
+    void RemoveUTF16String(uint16_t*);
+
     static v8::Isolate* toV8(JerryIsolate* iso) { return reinterpret_cast<v8::Isolate*>(iso); }
     static JerryIsolate* fromV8(v8::Isolate* iso) { return reinterpret_cast<JerryIsolate*>(iso); }
     static JerryIsolate* fromV8(v8::internal::Isolate* iso) { return reinterpret_cast<JerryIsolate*>(iso); }
@@ -121,6 +125,7 @@ private:
     std::vector<JerryValue*> m_eternals;
     std::vector<JerryValue*> m_weakrefs;
     std::vector<v8::String::ExternalStringResource*> m_ext_str_res;
+    std::unordered_map<uint16_t*, std::u16string*> m_utf16strs;
 
     JerryPolyfill* m_fn_map_new;
     JerryPolyfill* m_fn_is_map;


### PR DESCRIPTION
Currently, String::Value does the same as String::Utf8Value because JerryScript supports only UTF-8 strings. Since hexadecimal and base64 decoders require UTF-16 strings, this patch helps to create UTF-16 strings from the already stored UTF-8 strings.

This patch helps to run [iotjs/test/run_pass/test_buffer_str_conv.js](https://github.com/jerryscript-project/iotjs/blob/master/test/run_pass/test_buffer_str_conv.js) perfectly.