### PR TITLE
Improve handling of escaped eternal local values

### DIFF
--- a/deps/jerry-v8/src/v8jerry_handlescope.cpp
+++ b/deps/jerry-v8/src/v8jerry_handlescope.cpp
@@ -32,7 +32,13 @@ void JerryHandleScope::AddHandle(JerryHandle* jvalue) {
     m_handles.push_back(jvalue);
 }
 
-void JerryHandleScope::RemoveHandle(JerryHandle* jvalue) {
-    // TODO: check if it really exists
-    m_handles.erase(std::find(m_handles.begin(), m_handles.end(), jvalue));
+bool JerryHandleScope::RemoveHandle(JerryHandle* jvalue) {
+    std::vector<JerryHandle*>::iterator it = std::find(m_handles.begin(), m_handles.end(), jvalue);
+
+    if (it == m_handles.end()) {
+        return false;
+    }
+
+    m_handles.erase(it);
+    return true;
 }

--- a/deps/jerry-v8/src/v8jerry_handlescope.hpp
+++ b/deps/jerry-v8/src/v8jerry_handlescope.hpp
@@ -22,7 +22,7 @@ public:
     ~JerryHandleScope();
 
     void AddHandle(JerryHandle* jvalue);
-    void RemoveHandle(JerryHandle* jvalue);
+    bool RemoveHandle(JerryHandle* jvalue);
 
     void* V8HandleScope(void) { return m_v8handle_scope; }
 

--- a/deps/jerry-v8/src/v8jerry_isolate.cpp
+++ b/deps/jerry-v8/src/v8jerry_isolate.cpp
@@ -264,9 +264,14 @@ void JerryIsolate::EscapeHandle(JerryHandle* jvalue) {
     assert(m_handleScopes.size() > 1);
 
     std::deque<JerryHandleScope*>::reverse_iterator end = m_handleScopes.rbegin();
-    (*end)->RemoveHandle(jvalue);
-    ++end; // Step to a parent handleScope
-    (*end)->AddHandle(jvalue);
+    bool was_removed = (*end)->RemoveHandle(jvalue);
+    // If the handle was removed simply add it to the parent handle scope.
+    // However if it was not in the current handle scope (was not removed)
+    // then the value is a refernece to an enternal element, thus there is nothing to do.
+    if (was_removed) {
+        ++end; // Step to a parent handleScope
+        (*end)->AddHandle(jvalue);
+    }
 }
 
 void JerryIsolate::SealHandleScope(void* handle_scope) {


### PR DESCRIPTION
When a local value of an eternal object/value was
"escaped" form a handle scope the previous process
incorrectly added the value to the parent handle scope
which should have not happen as the eternal will clean
the underlying value away.