### PR TITLE
Use free() when releasing external array buffer data

### DIFF
--- a/deps/jerry-v8/src/v8jerry.cpp
+++ b/deps/jerry-v8/src/v8jerry.cpp
@@ -241,7 +241,7 @@ Locker::~Locker() {
 
 /* ArrayBuffer & Allocator */
 void delete_external_array_buffer(void* ptr) {
-    delete [] static_cast<uint8_t*> (ptr);
+    free(static_cast<uint8_t*> (ptr));
 }
 
 Local<ArrayBuffer> ArrayBuffer::New(Isolate* isolate, void* data, size_t byte_length, ArrayBufferCreationMode mode) {

--- a/deps/jerry-v8/tests/arraybuffer.cpp
+++ b/deps/jerry-v8/tests/arraybuffer.cpp
@@ -23,7 +23,7 @@ int main(int argc, char* argv[]) {
     // ArrayBuffer
     //
 
-    uint8_t* data = new uint8_t[ARRAY_SIZE];
+    uint8_t* data = (uint8_t*)malloc(sizeof(uint8_t) * ARRAY_SIZE);
     memset(data, 0, ARRAY_SIZE);
     data[0] = 1;
     data[1] = 1;


### PR DESCRIPTION
Node uses buffers allocated with malloc/realloc when
creating ArrayBuffers, thus the V8-Jerry binding should
also use free() when releasing the allocated buffer.