### PR TITLE
Add Object.entries polyfill

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -12,6 +12,19 @@
 _ref) {
 
   // Polyfill methods.
+  // Imported from: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries
+  if (!Object.entries) {
+    Object.entries = function(obj){
+      var ownProps = Object.keys(obj);
+      var i = ownProps.length;
+      resArray = new Array(i); // preallocate the Array
+      while (i--) {
+            resArray[i] = [ownProps[i], obj[ownProps[i]]];
+      }
+      return resArray;
+    };
+  }
+
   // TODO: implement them in JerryScript.
   if (!Object.getOwnPropertyDescriptors) {
     Object.defineProperty(Object, 'getOwnPropertyDescriptors', {


### PR DESCRIPTION
JerryScript does not support Object.entries at this moment.
However it is possible to add it as a polyfill.