### PR TITLE
Fix Value::{Int32,Uint32,Number,Boolean,Integer}Value implementation

### DIFF
--- a/deps/jerry-v8/src/v8jerry.cpp
+++ b/deps/jerry-v8/src/v8jerry.cpp
@@ -673,52 +673,88 @@ SealHandleScope::~SealHandleScope() {
 /* Value */
 Maybe<int32_t> Value::Int32Value(Local<Context> context) const {
     V8_CALL_TRACE();
-    return Just((int32_t)reinterpret_cast<const JerryValue*>(this)->GetInt64Value());
+    int32_t result = 0;
+    JerryValue* convertedValue = reinterpret_cast<const JerryValue*>(this)->ToInteger();
+
+    if (convertedValue != NULL) {
+        result = convertedValue->GetInt32Value();
+        delete convertedValue;
+    }
+
+    return Just(result);
 }
 
 int32_t Value::Int32Value() const {
     V8_CALL_TRACE();
-    return (int32_t)reinterpret_cast<const JerryValue*>(this)->GetInt64Value();
+    return Int32Value({}).ToChecked();
 }
 
 Maybe<uint32_t> Value::Uint32Value(Local<Context> context) const {
     V8_CALL_TRACE();
-    return Just((uint32_t)reinterpret_cast<const JerryValue*>(this)->GetUInt32Value());
+    uint32_t result = 0;
+    // TODO: Use ToUint32 conversion if available.
+    JerryValue* convertedValue = reinterpret_cast<const JerryValue*>(this)->ToInteger();
+
+    if (convertedValue != NULL) {
+        double value = convertedValue->GetNumberValue();
+
+        result = (value >= 0) ? (uint32_t)value : 0;
+        delete convertedValue;
+    }
+
+    return Just(result);
 }
 
 uint32_t Value::Uint32Value() const {
     V8_CALL_TRACE();
-    return reinterpret_cast<const JerryValue*> (this)->GetUInt32Value();
+    return Uint32Value({}).ToChecked();
 }
 
 Maybe<bool> Value::BooleanValue(Local<Context> context) const {
     V8_CALL_TRACE();
-    return Just((bool)reinterpret_cast<const JerryValue*>(this)->GetBooleanValue());
+    bool result = reinterpret_cast<const JerryValue*>(this)->ToBoolean();
+    return Just(result);
 }
 
 bool Value::BooleanValue() const {
     V8_CALL_TRACE();
-    return (bool)reinterpret_cast<const JerryValue*>(this)->GetBooleanValue();
+    return BooleanValue({}).ToChecked();
 }
 
 Maybe<double> Value::NumberValue(Local<Context> context) const {
     V8_CALL_TRACE();
-    return Just((double)reinterpret_cast<const JerryValue*>(this)->GetNumberValue());
+    double result = 0.0;
+    JerryValue* convertedValue = reinterpret_cast<const JerryValue*>(this)->ToInteger();
+
+    if (convertedValue != NULL) {
+        result = convertedValue->GetNumberValue();
+        delete convertedValue;
+    }
+
+    return Just(result);
 }
 
 double Value::NumberValue() const {
     V8_CALL_TRACE();
-    return (double)reinterpret_cast<const JerryValue*>(this)->GetNumberValue();
-}
-
-int64_t Value::IntegerValue() const {
-    V8_CALL_TRACE();
-    return (int64_t)reinterpret_cast<const JerryValue*>(this)->GetInt64Value();
+    return NumberValue({}).ToChecked();
 }
 
 Maybe<int64_t> Value::IntegerValue(Local<Context> context) const {
     V8_CALL_TRACE();
-    return Just((int64_t)reinterpret_cast<const JerryValue*>(this)->GetInt64Value());
+    int64_t result = 0;
+    JerryValue* convertedValue = reinterpret_cast<const JerryValue*>(this)->ToInteger();
+
+    if (convertedValue != NULL) {
+        result = convertedValue->GetInt64Value();
+        delete convertedValue;
+    }
+
+    return Just(result);
+}
+
+int64_t Value::IntegerValue() const {
+    V8_CALL_TRACE();
+    return IntegerValue({}).ToChecked();
 }
 
 MaybeLocal<String> Value::ToString(Local<Context> context) const {

--- a/deps/jerry-v8/src/v8jerry_value.hpp
+++ b/deps/jerry-v8/src/v8jerry_value.hpp
@@ -148,6 +148,11 @@ public:
         return new JerryValue(jerry_value_to_number(m_value));
     }
 
+    bool ToBoolean(void) const {
+        // TODO: error handling?
+        return jerry_value_to_boolean(m_value);
+    }
+
     JerryValue* ToObject(void) const {
         // TODO: error handling?
         return new JerryValue(jerry_value_to_object(m_value));

--- a/deps/jerry-v8/tests/string.cpp
+++ b/deps/jerry-v8/tests/string.cpp
@@ -1,6 +1,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <cmath>
+
 #include "v8env.h"
 #include "assert.h"
 
@@ -72,6 +74,55 @@ int main(int argc, char* argv[]) {
     memset(buffer, 0, sizeof(buffer));
     helloworld->WriteOneByte((uint8_t*)buffer, 1, 4, 0);
     ASSERT_STR_EQUAL(buffer, "ello");
+
+    // Test conversions
+    {
+        v8::Local<v8::String> str_data = v8::String::NewFromUtf8(env.getIsolate(), "11", v8::NewStringType::kNormal).ToLocalChecked();
+        v8::Local<v8::Value> data = str_data.As<v8::Value>();
+        ASSERT_EQUAL(data->IsString(), true);
+        ASSERT_EQUAL(data->IsInt32(), false);
+        ASSERT_EQUAL(data->Int32Value(), 11);
+    }
+
+    {
+        v8::Local<v8::String> str_data = v8::String::NewFromUtf8(env.getIsolate(), "-11", v8::NewStringType::kNormal).ToLocalChecked();
+        v8::Local<v8::Value> data = str_data.As<v8::Value>();
+        ASSERT_EQUAL(data->IsString(), true);
+        ASSERT_EQUAL(data->IsUint32(), false);
+        ASSERT_EQUAL(data->Uint32Value(), 0);
+    }
+
+    {
+        v8::Local<v8::String> str_data = v8::String::NewFromUtf8(env.getIsolate(), "true", v8::NewStringType::kNormal).ToLocalChecked();
+        v8::Local<v8::Value> data = str_data.As<v8::Value>();
+        ASSERT_EQUAL(data->IsString(), true);
+        ASSERT_EQUAL(data->IsBoolean(), false);
+        ASSERT_EQUAL(data->BooleanValue(), true);
+    }
+
+    {
+        v8::Local<v8::String> str_data = v8::String::NewFromUtf8(env.getIsolate(), "false", v8::NewStringType::kNormal).ToLocalChecked();
+        v8::Local<v8::Value> data = str_data.As<v8::Value>();
+        ASSERT_EQUAL(data->IsString(), true);
+        ASSERT_EQUAL(data->IsBoolean(), false);
+        ASSERT_EQUAL(data->BooleanValue(), true);
+    }
+
+    {
+        v8::Local<v8::String> str_data = v8::String::NewFromUtf8(env.getIsolate(), "43.34", v8::NewStringType::kNormal).ToLocalChecked();
+        v8::Local<v8::Value> data = str_data.As<v8::Value>();
+        ASSERT_EQUAL(data->IsString(), true);
+        ASSERT_EQUAL(data->IsNumber(), false);
+        ASSERT_EQUAL(data->NumberValue(), 43.34);
+    }
+
+    {
+        v8::Local<v8::String> str_data = v8::String::NewFromUtf8(env.getIsolate(), "true", v8::NewStringType::kNormal).ToLocalChecked();
+        v8::Local<v8::Value> data = str_data.As<v8::Value>();
+        ASSERT_EQUAL(data->IsString(), true);
+        ASSERT_EQUAL(data->IsNumber(), false);
+        ASSERT_EQUAL(std::isnan(data->NumberValue()), true);
+    }
 
     return 0;
 }


### PR DESCRIPTION
The Value::*Value methods should do conversion which was missing
before.