### PR TITLE
Correctly terminate js execution on Isolate::Terminate call

### DIFF
--- a/deps/jerry-v8/deps/CMakeLists.txt
+++ b/deps/jerry-v8/deps/CMakeLists.txt
@@ -25,6 +25,7 @@ target_compile_definitions(jerry PUBLIC
     JERRY_LINE_INFO=1
     JERRY_SYSTEM_ALLOCATOR=1
     JERRY_CPOINTER_32_BIT=1
+    JERRY_VM_EXEC_STOP=1
 )
 
 add_library(v8headers INTERFACE)

--- a/deps/jerry-v8/deps/jerryscript.gyp
+++ b/deps/jerry-v8/deps/jerryscript.gyp
@@ -52,7 +52,8 @@
         'JERRY_ERROR_MESSAGES=1',
         'JERRY_LINE_INFO=1', 
         'JERRY_SYSTEM_ALLOCATOR=1',
-        'JERRY_CPOINTER_32_BIT=1'
+        'JERRY_CPOINTER_32_BIT=1',
+        'JERRY_VM_EXEC_STOP=1'
       ],
 
       'sources': [

--- a/deps/jerry-v8/src/v8jerry_isolate.cpp
+++ b/deps/jerry-v8/src/v8jerry_isolate.cpp
@@ -54,6 +54,21 @@ void JerryIsolate::Exit(void) {
     }
 }
 
+static jerry_value_t IsolateTerminateCallback(void *user_p) {
+    return jerry_create_string ((const jerry_char_t *) "Script Abort Requested");
+}
+
+void JerryIsolate::Terminate(void) {
+    m_terminated = true;
+
+    jerry_set_vm_exec_stop_callback(IsolateTerminateCallback, NULL, 1);
+}
+
+void JerryIsolate::CancelTerminate(void) {
+    m_terminated = false;
+    jerry_set_vm_exec_stop_callback(NULL, NULL, 1);
+}
+
 namespace v8 {
     namespace internal {
         class Heap {

--- a/deps/jerry-v8/src/v8jerry_isolate.hpp
+++ b/deps/jerry-v8/src/v8jerry_isolate.hpp
@@ -41,8 +41,8 @@ public:
     void Enter(void);
     void Exit(void);
     bool IsTerminated(void) const { return m_terminated; }
-    void Terminate(void) { m_terminated = true; }
-    void CancelTerminate(void) { m_terminated = false; }
+    void Terminate(void);
+    void CancelTerminate(void);
 
     void RunWeakCleanup(void);
     void Dispose(void);

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -92,7 +92,7 @@ function sigintHandlersWrap(fn, thisArg, argsArray) {
   try {
     return fn.apply(thisArg, argsArray);
   } finally {
-    var size = sigintListeners.length();
+    var size = sigintListeners.length;
     for (var idx in sigintListeners) {
       var listener = sigintListeners[idx];
       process.addListener('SIGINT', listener);


### PR DESCRIPTION
Added termination stop callback for the JerryScript binding.
