### PR TITLE
Add initial 64 bit support

### DIFF
--- a/deps/jerry-v8/deps/CMakeLists.txt
+++ b/deps/jerry-v8/deps/CMakeLists.txt
@@ -20,13 +20,26 @@ add_custom_command(OUTPUT ${JERRY_SOURCES}
 add_library(jerry STATIC ${JERRY_SOURCES})
 target_include_directories(jerry PUBLIC ${JERRY_GEN_DIR})
 target_compile_definitions(jerry PUBLIC
-    JERRY_GLOBAL_HEAP_SIZE=10*1024
     JERRY_ERROR_MESSAGES=1
     JERRY_LINE_INFO=1
-    JERRY_SYSTEM_ALLOCATOR=1
     JERRY_CPOINTER_32_BIT=1
     JERRY_VM_EXEC_STOP=1
 )
+
+if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+    message("-- Configured JerryScript for: 32 bit")
+    target_compile_definitions(jerry PUBLIC
+        JERRY_SYSTEM_ALLOCATOR=1
+    )
+elseif(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    message("-- Configured JerryScript for: 64 bit")
+    target_compile_definitions(jerry PUBLIC
+        JERRY_GLOBAL_HEAP_SIZE=200*1024
+        JERRY_SYSTEM_ALLOCATOR=0
+    )
+else()
+    message(FATAL_ERROR "-- Incorrect sizeof(void*)")
+endif()
 
 add_library(v8headers INTERFACE)
 target_include_directories(v8headers INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/v8-headers)

--- a/deps/jerry-v8/deps/jerryscript.gyp
+++ b/deps/jerry-v8/deps/jerryscript.gyp
@@ -48,12 +48,10 @@
         ]
       },
       'defines': [
-        'JERRY_GLOBAL_HEAP_SIZE=10*1024',
         'JERRY_ERROR_MESSAGES=1',
         'JERRY_LINE_INFO=1', 
-        'JERRY_SYSTEM_ALLOCATOR=1',
         'JERRY_CPOINTER_32_BIT=1',
-        'JERRY_VM_EXEC_STOP=1'
+        'JERRY_VM_EXEC_STOP=1',
       ],
 
       'sources': [
@@ -66,6 +64,17 @@
         '-msse2',
       ],
       'conditions': [
+        ['target_arch=="x64"', {
+          'defines': [
+            'JERRY_SYSTEM_ALLOCATOR=0',
+            'JERRY_GLOBAL_HEAP_SIZE=(200*1024)',
+          ]
+        }, {
+          'defines': [
+            'JERRY_SYSTEM_ALLOCATOR=1'
+          ]
+        }],
+
         ['want_separate_host_toolset==1', {
           'toolsets': ['host', 'target'],
         }, {

--- a/deps/jerry-v8/src/v8jerry_utils.cpp
+++ b/deps/jerry-v8/src/v8jerry_utils.cpp
@@ -60,7 +60,10 @@ extern "C" bool ecma_get_object_is_builtin(void* obj);
 #define ECMA_OBJECT_REF_ONE (1u << 6)
 #define ECMA_OBJECT_MAX_REF (0x3ffu << 6)
 #define ECMA_VALUE_TYPE_MASK 0x7u
+#define ECMA_VALUE_SHIFT 3
 typedef uint32_t ecma_value_t;
+
+extern "C" void * jmem_decompress_pointer (uintptr_t compressed_pointer);
 
 typedef struct {
   /** type : 4 bit : ecma_object_type_t or ecma_lexical_environment_type_t
@@ -73,7 +76,11 @@ typedef struct {
 } header_ecma_object_t;
 
 static void *ecma_get_pointer_from_ecma_value (ecma_value_t value) {
+#if __UINTPTR_MAX__ <= __UINT32_MAX__
   void *ptr = (void *) (uintptr_t) ((value) & ~ECMA_VALUE_TYPE_MASK);
+#else
+  void *ptr = (void*)jmem_decompress_pointer(value >> ECMA_VALUE_SHIFT);
+#endif
   return ptr;
 }
 


### PR DESCRIPTION
Previously only the 32 bit build was running due to the
expected layout values returned from JerryScript.

The `--dest-cpu` configuration option should be set to `x86_64`
to build for Intel 64 bit.