### PR TITLE
Add support for FunctionTemplate signature checking

### DIFF
--- a/deps/jerry-v8/src/v8jerry.cpp
+++ b/deps/jerry-v8/src/v8jerry.cpp
@@ -2149,6 +2149,9 @@ Local<FunctionTemplate> FunctionTemplate::New(Isolate* isolate,
     // TODO: handle the other args
     JerryFunctionTemplate* func = new JerryFunctionTemplate();
     reinterpret_cast<FunctionTemplate*>(func)->SetCallHandler(callback, data);
+    if (!signature.IsEmpty()) {
+        func->SetSignature(reinterpret_cast<JerryHandle*>(*signature));
+    }
 
     RETURN_HANDLE(FunctionTemplate, isolate, func);
 }

--- a/deps/jerry-v8/src/v8jerry_callback.cpp
+++ b/deps/jerry-v8/src/v8jerry_callback.cpp
@@ -277,6 +277,16 @@ jerry_value_t JerryV8FunctionHandler(
         }
     }
 
+    if (data->function_template->HasSignature()) {
+        JerryV8FunctionHandlerData* this_val_data;
+        bool has_info = jerry_get_object_native_pointer(this_val, reinterpret_cast<void**>(&this_val_data), &JerryV8ObjectConstructed);
+        if (!has_info
+            || data->function_template->IsValidSignature(this_val_data->function_template->Signature())) {
+            // Invalid signature found throw error.
+            return jerry_create_error (JERRY_ERROR_TYPE, (const jerry_char_t *) "Incorrect signature");
+        }
+    }
+
     jerry_value_t jret = jerry_create_undefined();
 
     if (data->v8callback != NULL) {

--- a/deps/jerry-v8/src/v8jerry_templates.hpp
+++ b/deps/jerry-v8/src/v8jerry_templates.hpp
@@ -210,6 +210,7 @@ public:
         , m_instance_template(NULL)
         , m_external(jerry_create_undefined())
         , m_function(NULL)
+        , m_signature(NULL)
     {
     }
 
@@ -227,6 +228,10 @@ public:
 
     void SetCallback(v8::FunctionCallback callback) { m_callback = callback; }
     void SetExternalData(jerry_value_t value) { m_external = value; }
+    void SetSignature(JerryHandle* handle) { m_signature = handle; }
+    bool HasSignature(void) const { return m_signature != NULL; }
+    bool IsValidSignature(const JerryHandle* handle) { return m_signature == handle; }
+    const JerryHandle* Signature(void) const { return m_signature; }
 
     v8::FunctionCallback callback(void) const { return m_callback; }
     jerry_value_t external(void) const { return m_external; }
@@ -238,6 +243,7 @@ private:
     v8::FunctionCallback m_callback;
     jerry_value_t m_external;
     JerryValue* m_function;
+    JerryHandle* m_signature;
 };
 
 #endif /* V8JERRY_TEMPLATES_HPP */

--- a/deps/jerry-v8/tests/CMakeLists.txt
+++ b/deps/jerry-v8/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ add_test(test_hello.cpp)
 
 add_test(arraybuffer.cpp)
 add_test(handle_scope.cpp)
+add_test(function_template.cpp)
 add_test(local_alloc.cpp)
 add_test(object.cpp)
 add_test(object_accessor.cpp)

--- a/deps/jerry-v8/tests/function_template.cpp
+++ b/deps/jerry-v8/tests/function_template.cpp
@@ -1,0 +1,122 @@
+#include "v8env.h"
+#include "assert.h"
+
+void method_demo(const v8::FunctionCallbackInfo<v8::Value>& info) {
+    info.GetReturnValue().Set(v8::String::NewFromUtf8(info.GetIsolate(), "ACCESSED"));
+}
+
+int main(int argc, char* argv[]) {
+    // Initialize V8.
+    V8Environment env(argc, argv);
+
+    v8::Local<v8::String> protoString = v8::String::NewFromUtf8(env.getIsolate(), "prototype");
+    v8::Local<v8::String> getPropOkString = v8::String::NewFromUtf8(env.getIsolate(), "getpropOk");
+    v8::Local<v8::String> getPropErrorString = v8::String::NewFromUtf8(env.getIsolate(), "getpropError");
+
+    v8::Local<v8::FunctionTemplate> tmplt = v8::FunctionTemplate::New(env.getIsolate());
+    {
+        v8::Local<v8::ObjectTemplate> prototype = tmplt->PrototypeTemplate();
+
+        prototype->SetInternalFieldCount(1);
+
+        v8::Local<v8::String> nameKey = v8::String::NewFromUtf8(env.getIsolate(), "Foo");
+        v8::Local<v8::String> demoString = v8::String::NewFromUtf8(env.getIsolate(), "demo");
+        prototype->Set(nameKey, demoString);
+
+        // By configuring the signature for a template method it should throw an error if an incorrect "this" value is used during access.
+        {
+            v8::Local<v8::Signature> signature = v8::Signature::New(env.getIsolate(), tmplt);
+            v8::Local<v8::FunctionTemplate> getprop_method =
+                v8::FunctionTemplate::New(env.getIsolate(), method_demo, v8::Local<v8::External>(), signature);
+
+            prototype->SetAccessorProperty(getPropErrorString, getprop_method, v8::Local<v8::FunctionTemplate>());
+        }
+
+        // Without a signature the template method should work in every case
+        {
+            v8::Local<v8::FunctionTemplate> getprop_method = v8::FunctionTemplate::New(env.getIsolate(), method_demo);
+            prototype->SetAccessorProperty(getPropOkString, getprop_method, v8::Local<v8::FunctionTemplate>());
+        }
+    }
+
+    v8::Local<v8::Function> func = tmplt->GetFunction();
+    {
+        env.getContext()->Global()->Set(
+            v8::String::NewFromUtf8(env.getIsolate(), "DemoFunc"),
+            func);
+    }
+
+    ASSERT_EQUAL(func->InternalFieldCount(), 0);
+
+    v8::Local<v8::Value> prototypeVal = func->Get(protoString);
+    ASSERT_EQUAL(prototypeVal->IsObject(), true);
+    v8::Local<v8::Object> prototype = prototypeVal.As<v8::Object>();
+    ASSERT_EQUAL(prototype->InternalFieldCount(), 1);
+
+    // Test the "prototype.getpropError" via object.get
+    {
+        v8::TryCatch tc(env.getIsolate());
+
+        v8::Local<v8::Value> result = prototype->Get(v8::String::NewFromUtf8(env.getIsolate(), "getpropError"));
+        ASSERT_EQUAL(result.IsEmpty(), true);
+        ASSERT_EQUAL(tc.HasCaught(), true);
+    }
+
+    // Test the "prototype.getpropError" via JS code
+    {
+        v8::TryCatch tc(env.getIsolate());
+
+        v8::Local<v8::String> source = v8::String::NewFromUtf8(env.getIsolate(), "DemoFunc.prototype.getpropError");
+        v8::Local<v8::Script> script = v8::Script::Compile(env.getContext(), source).ToLocalChecked();
+        v8::MaybeLocal<v8::Value> result = script->Run(env.getContext());
+        ASSERT_EQUAL(result.IsEmpty(), true);
+        ASSERT_EQUAL(tc.HasCaught(), true);
+    }
+
+    // Test "instance.getpropError" via object.get should not throw error
+    {
+        v8::TryCatch tc(env.getIsolate());
+
+        v8::Local<v8::Object> instance = func->NewInstance(0, NULL);
+        v8::Local<v8::Value> result = instance->Get(v8::String::NewFromUtf8(env.getIsolate(), "getpropError"));
+        ASSERT_EQUAL(result.IsEmpty(), false);
+        ASSERT_EQUAL(result->IsString(), true);
+        ASSERT_EQUAL(tc.HasCaught(), false);
+
+        v8::String::Utf8Value utf8(env.getIsolate(), result.As<v8::String>());
+        ASSERT_STR_EQUAL("ACCESSED", *utf8);
+    }
+
+    // Test "instance.getpropError" via JS code should not throw error
+    {
+        v8::TryCatch tc(env.getIsolate());
+
+        v8::Local<v8::String> source = v8::String::NewFromUtf8(env.getIsolate(), "(new DemoFunc).getpropError");
+        v8::Local<v8::Script> script = v8::Script::Compile(env.getContext(), source).ToLocalChecked();
+        v8::MaybeLocal<v8::Value> eval_result = script->Run(env.getContext());
+        ASSERT_EQUAL(eval_result.IsEmpty(), false);
+
+        v8::Local<v8::Value> result = eval_result.ToLocalChecked();
+        ASSERT_EQUAL(result->IsString(), true);
+        ASSERT_EQUAL(tc.HasCaught(), false);
+
+        v8::String::Utf8Value utf8(env.getIsolate(), result.As<v8::String>());
+        ASSERT_STR_EQUAL("ACCESSED", *utf8);
+    }
+
+    // Access elements from prototype "(new DemoFunc).Foo"
+    {
+        v8::TryCatch tc(env.getIsolate());
+
+        v8::Local<v8::Object> instance = func->NewInstance(0, NULL);
+        v8::Local<v8::Value> result = instance->Get(v8::String::NewFromUtf8(env.getIsolate(), "Foo"));
+        ASSERT_EQUAL(result.IsEmpty(), false);
+        ASSERT_EQUAL(result->IsString(), true);
+        ASSERT_EQUAL(tc.HasCaught(), false);
+
+        v8::String::Utf8Value utf8(env.getIsolate(), result.As<v8::String>());
+        ASSERT_STR_EQUAL("demo", *utf8);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
The FunctionTemplate's signature is used to check if a method
is invoked on a correct instance.