### PR TITLE
fix: disable hack argv pointer for Tizen build

### DIFF
--- a/deps/bindings/bindings.gyp
+++ b/deps/bindings/bindings.gyp
@@ -1,6 +1,13 @@
 {
   'variables': {
-    'deps_path%': '..'
+    'deps_path%': '..',
+    'host_platform%': 'none',
+    'platform_libs%': '',
+    'conditions': [
+      ['host_platform=="tizen"', {
+        'platform_libs': 'dlog'
+      }],
+    ],
   },
   'targets': [
     {
@@ -8,7 +15,7 @@
       'type': '<(library)',
       'dependencies': [ '<(deps_path)/uv/uv.gyp:libuv' ],
       'cflags': [
-        '<!@(pkg-config --cflags glib-2.0)',
+        '<!@(pkg-config --cflags glib-2.0 <(platform_libs))',
       ],
       'include_dirs': [
         'src',
@@ -21,10 +28,10 @@
           'ENABLE_NODE_BINDINGS'
         ],
         'cflags': [
-          '<!@(pkg-config --cflags glib-2.0)',
+          '<!@(pkg-config --cflags glib-2.0 <(platform_libs))',
         ],
         'libraries': [
-          '<!@(pkg-config --libs glib-2.0)',
+          '<!@(pkg-config --libs glib-2.0 <(platform_libs))',
         ],
         'include_dirs': [
           'src',

--- a/src/node.cc
+++ b/src/node.cc
@@ -4331,8 +4331,10 @@ int Start(int argc, char** argv) {
 
   CHECK_GT(argc, 0);
 
+#if !defined(HOST_TIZEN)
   // Hack around with the argv pointer. Used for process.title = "blah".
   argv = uv_setup_args(argc, argv);
+#endif
 
   // This needs to run *before* V8::Initialize().  The const_cast is not
   // optional, in case you're wondering.


### PR DESCRIPTION
This patch also includes dlog configuration for node-bindings.

Signed-off-by: Daeyeon Jeong daeyeon.jeong@samsung.com