### PR TITLE
Fix engine randomization

### DIFF
--- a/deps/jerry/v8jerry/v8jerry_isolate.cpp
+++ b/deps/jerry/v8jerry/v8jerry_isolate.cpp
@@ -157,6 +157,9 @@ void JerryIsolate::InitializeJerryIsolate(const v8::Isolate::CreateParams& param
     m_current_error = NULL;
     m_hidden_object_template = NULL;
 
+    // Initialize random for math functions
+    srand((unsigned)time(NULL));
+
 #ifdef __POSIX__
     m_lock = PTHREAD_MUTEX_INITIALIZER;
 #endif


### PR DESCRIPTION
Calling srand() will init a random seed for the engine in InitializeJerryIsolate.

JerryScript-DCO-1.0-Signed-off-by: Bela Toth tbela@inf.u-szeged.hu
